### PR TITLE
Removed devjoke from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@
 - [CompetitiveCode](https://github.com/Vishruth-S/CompetitiveCode)
 - [competicoes-de-programacao](https://github.com/ifpeopensource/competicoes-de-programacao/)
 - [css-puns](https://github.com/cmcodes1/css-puns)
-- [DevJoke](https://github.com/shrutikapoor08/devjoke)
 - [Developer Experience Knowledge Base](https://github.com/DXHeroes/knowledge-base-content)
 - [Data Structure and Algo](https://github.com/dheeraj-2000/dsalgo)
 - [Filosofunk](https://github.com/IgorRozani/filosofunk)


### PR DESCRIPTION
This repo doesn't have the "hacktoberfest" tag.

## Contributing

If you want to add a project to this list, please make sure that:

(I removed the task-list since I'm removing a project and not adding one)
