### PR TITLE
remove devjoke repo from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@
 - [CompetitiveCode](https://github.com/Vishruth-S/CompetitiveCode)
 - [competicoes-de-programacao](https://github.com/ifpeopensource/competicoes-de-programacao/)
 - [css-puns](https://github.com/cmcodes1/css-puns)
-- [DevJoke](https://github.com/shrutikapoor08/devjoke)
 - [Developer Experience Knowledge Base](https://github.com/DXHeroes/knowledge-base-content)
 - [Data Structure and Algo](https://github.com/dheeraj-2000/dsalgo)
 - [Filosofunk](https://github.com/IgorRozani/filosofunk)


### PR DESCRIPTION
according to the readme of the devjoke repo it no longer participates in hacktober fest:
https://github.com/shrutikapoor08/devjoke/blob/master/README.md?plain=1#L2
