### PR TITLE
removed git-osp repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@
 - [Filosofunk](https://github.com/IgorRozani/filosofunk)
 - [Flyte](https://github.com/flyteorg/flyte)
 - [Freshbey](https://github.com/roopeshsn/freshbey)
-- [git-osp-beginners](https://github.com/aditya109/git-osp-for-beginners)
 - [Hacktoberfest Animations](https://github.com/NiallEccles/Hacktoberfest-animations)
 - [hacktoberfest-java](https://github.com/BimalRajGyawali/hacktoberfest-java)
 - [Hasura GraphQL Engine](https://github.com/hasura/graphql-engine)


### PR DESCRIPTION
## Contributing

Removed a repository "git-osp-for-beginners" since that repository has been archived by the owner and is now read-only repository. That means coders can no longer contribute to that repository.
